### PR TITLE
Bug Fix: Allow editing and deleting of images to only image owner

### DIFF
--- a/src/main/resources/templates/images/image.html
+++ b/src/main/resources/templates/images/image.html
@@ -16,14 +16,14 @@
         <a th:href="@{/editImage(imageId=${image.id})}">Edit</a>
         <!-- Show the edit error if the non owner of the image is trying to edit the image-->
         <!--Uncomment the below code to show the error if the non owner of the image is trying to edit the image-->
-        <!--<div th:if="${editError}">Only the owner of the image can edit the image</div>-->
+        <div th:if="${editError}">Only the owner of the image can edit the image</div>
         <div><br></div>
         <form th:action="@{/deleteImage(imageId=${image.id})}" th:method="delete">
             <input type="submit" value="Delete"/>
         </form>
         <!-- Show the delete error if the non owner of the image is trying to delete the image-->
         <!--Uncomment the below code to show the error if the non owner of the image is trying to delete the image-->
-        <!--<div th:if="${deleteError}">Only the owner of the image can delete the image</div>-->
+        <div th:if="${deleteError}">Only the owner of the image can delete the image</div>
     </div>
 </nav>
 


### PR DESCRIPTION
The issue: No check on the details of the user when the image is edited/deleted. Before editing/deleting the image, the owner of the image is not compared to the user, who is trying to edit/delete the image.

Fix: Check added to only allow image up-loader to edit or delete the image. Else display error.